### PR TITLE
When encoding a string as Html, use named codes

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -43,7 +43,7 @@ class StringToHtmlEntitiesTransformer implements Transformer {
 	}
 	
 	public transform(input: string): string {
-		let output = ent.encode(input);
+		let output = ent.encode(input, { named: true });
 		return output;
 	}
 }


### PR DESCRIPTION
I think for the web developer named codes rather than numeric codes are more helpful. `node-ent` supports this via `opts.named = true`

What do you think?