### PR TITLE
Added 'String to HTML Entities (as Decimal Entity)' option.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -122,6 +122,7 @@ function selectAndApplyTransformation(textEditor: vscode.TextEditor, edit: vscod
 		new jsonarray.Base64ToJsonArrayTransformer(),
 		new md5.StringToMD5Transformer(),
 		new htmlentities.StringToHtmlEntitiesTransformer(),
+		new htmlentities.StringToHtmlDecimalEntitiesTransformer(),
 		new htmlentities.HtmlEntitiesToStringTransformer(),
 		new crockford32.IntegerToCrockfordBase32Transformer(),
 		new crockford32.CrockfordBase32ToIntegerTransformer(),

--- a/lib/htmlentities.ts
+++ b/lib/htmlentities.ts
@@ -38,3 +38,22 @@ export class StringToHtmlEntitiesTransformer implements core.Transformer {
 		return output;
 	}
 }
+
+export class StringToHtmlDecimalEntitiesTransformer implements core.Transformer {
+	public get label(): string {
+		return 'String to HTML Entities (as Decimal Entity)';	
+	}
+	
+	public get description(): string {
+		return this.label;
+	}
+	
+	public check(input: string): boolean {
+		return true;
+	}
+	
+	public transform(input: string): string {
+		let output = ent.encode(input, { named: false });
+		return output;
+	}
+}


### PR DESCRIPTION
This pull request address the issue #13, by adding a new menu option called **String to HTML Entities (as Decimal Entity)**, so the user can choose which codification use case by case, and not only as a global option.


Regards!!
